### PR TITLE
Potential fix for code scanning alert no. 26: Disabling certificate validation

### DIFF
--- a/libraries/botbuilder-azure/tests/cosmosDbPartitionedStorage.test.js
+++ b/libraries/botbuilder-azure/tests/cosmosDbPartitionedStorage.test.js
@@ -190,7 +190,7 @@ describe('CosmosDbPartitionedStorage', function () {
 
             const settingsWithClientOptions = getSettings(this.test);
             settingsWithClientOptions.cosmosClientOptions = {
-                agent: new https.Agent({ rejectUnauthorized: false }),
+                agent: new https.Agent(),
                 connectionPolicy: { requestTimeout: 999 },
                 userAgentSuffix: 'test',
             };
@@ -209,7 +209,7 @@ describe('CosmosDbPartitionedStorage', function () {
 
             const settingsWithClientOptions = getSettings(this.test);
             settingsWithClientOptions.cosmosClientOptions = {
-                agent: new https.Agent({ rejectUnauthorized: false }),
+                agent: new https.Agent(),
                 connectionPolicy: { requestTimeout: 999 },
             };
 


### PR DESCRIPTION
Potential fix for [https://github.com/rido-min/botbuilder-js/security/code-scanning/26](https://github.com/rido-min/botbuilder-js/security/code-scanning/26)

To fix the problem, remove the `rejectUnauthorized: false` option from the `https.Agent` instantiations in the test cases. This will ensure that certificate validation is not disabled, even in tests. If the test does not require a custom agent, the `agent` property can be omitted entirely. If a custom agent is required for other reasons, instantiate it without the `rejectUnauthorized` option, so it defaults to `true`. Make these changes in both places: line 193 and line 212.

No new imports or methods are needed; simply remove the insecure option from the agent configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
